### PR TITLE
Fix image buffers

### DIFF
--- a/app/processing.py
+++ b/app/processing.py
@@ -47,5 +47,6 @@ def crop_and_flip(image: Image.Image, base_name: str, ext: str) -> list[tuple[st
         flipped.save(flip_buffer, format=fmt)
         flip_buffer.seek(0)
         outputs.append((flip_name, flip_buffer))
+        buffer.seek(0)
 
     return outputs

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -13,3 +13,8 @@ def test_crop_and_flip():
     filenames = [name for name, _ in result]
     assert 'test_top_left_flip.jpg' in filenames
     assert 'test_bottom_right.jpg' in filenames
+    # ensure buffers are valid images and rewound
+    for name, buf in result:
+        buf.seek(0)
+        loaded = Image.open(buf)
+        loaded.verify()


### PR DESCRIPTION
## Summary
- ensure image buffers are rewound after flipping
- verify buffers in tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686e33fcf9f883339c62cf04bffc1883