### PR TITLE
Add dataset archive web interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+archives/
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@ Creates 14 cropped and flipped images inside `output_dir`.
 ## Webserver API
 
 After installing the requirements, you can start a small Flask server that
-accepts image uploads and returns a ZIP archive with the processed files.
+accepts image uploads. Generated datasets are stored in an archive directory and
+can be downloaded from the web interface.
+Only the ten most recent datasets are kept; older archives are deleted
+automatically.
 
 ```bash
 python run.py

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,9 +7,30 @@
 </head>
 <body class="bg-gray-100 text-center p-8">
     <h1 class="text-3xl font-bold mb-4">OneShot Dataset Prep</h1>
-    <form action="/upload" method="POST" enctype="multipart/form-data" class="bg-white p-6 rounded shadow-md inline-block">
-        <input type="file" name="image" accept="image/*" required class="mb-4"><br>
-        <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Upload & Generate ZIP</button>
-    </form>
+    <div class="flex justify-center space-x-8">
+        <div>
+            <h2 class="text-xl font-semibold mb-2">Archiv</h2>
+            <table class="table-auto border-collapse">
+                <thead>
+                    <tr><th class="px-4 py-2 border">Dataset</th></tr>
+                </thead>
+                <tbody>
+                    {% for file in archives %}
+                    <tr>
+                        <td class="border px-4 py-2 text-left">
+                            <a href="{{ url_for('download', filename=file) }}" class="text-blue-600 underline">{{ file }}</a>
+                        </td>
+                    </tr>
+                    {% else %}
+                    <tr><td class="border px-4 py-2">No datasets yet</td></tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+        <form action="/upload" method="POST" enctype="multipart/form-data" class="bg-white p-6 rounded shadow-md">
+            <input type="file" name="image" accept="image/*" required class="mb-4"><br>
+            <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Upload & Generate ZIP</button>
+        </form>
+    </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- keep generated datasets in an `archives/` folder
- show the archive list on the main page with download links
- maintain only the 10 most recent dataset archives
- update documentation about the archive feature
- ignore archive files in git

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e36249a948333af178f811b76cf07