### PR TITLE
Add user accounts and dataset sharing

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,19 @@
-from flask import Flask, request, send_file, render_template, send_from_directory, redirect, url_for
+from flask import (
+    Flask,
+    request,
+    render_template,
+    send_from_directory,
+    redirect,
+    url_for,
+)
+from flask_login import (
+    LoginManager,
+    login_user,
+    logout_user,
+    login_required,
+    current_user,
+)
+from werkzeug.security import generate_password_hash, check_password_hash
 from PIL import Image
 from io import BytesIO
 import zipfile
@@ -14,21 +29,73 @@ app = Flask(
     template_folder=str(Path(__file__).resolve().parent.parent / "templates"),
     static_folder=str(Path(__file__).resolve().parent.parent / "static"),
 )
+app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///data.db"
+app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+app.config["SECRET_KEY"] = "replace-me"
+login_manager = LoginManager(app)
+login_manager.login_view = "login"
+
+from .models import db as models_db, User, Dataset, DatasetShare
+
+models_db.init_app(app)
+
+@login_manager.user_loader
+def load_user(user_id):
+    with app.app_context():
+        return User.query.get(int(user_id))
 
 ARCHIVE_DIR = Path(__file__).resolve().parent.parent / "archives"
 ARCHIVE_DIR.mkdir(exist_ok=True)
 
 
+@app.route("/register", methods=["GET", "POST"])
+def register():
+    if request.method == "POST":
+        username = request.form["username"]
+        password = request.form["password"]
+        if User.query.filter_by(username=username).first():
+            return "User exists", 400
+        user = User(username=username, password_hash=generate_password_hash(password))
+        models_db.session.add(user)
+        models_db.session.commit()
+        login_user(user)
+        return redirect(url_for("index"))
+    return render_template("register.html")
+
+
+@app.route("/login", methods=["GET", "POST"])
+def login():
+    if request.method == "POST":
+        username = request.form["username"]
+        password = request.form["password"]
+        user = User.query.filter_by(username=username).first()
+        if user and check_password_hash(user.password_hash, password):
+            login_user(user)
+            return redirect(url_for("index"))
+        return "Invalid credentials", 400
+    return render_template("login.html")
+
+
+@app.route("/logout")
+@login_required
+def logout():
+    logout_user()
+    return redirect(url_for("login"))
+
+
 @app.route("/", methods=["GET"])
+@login_required
 def index():
     """Render upload form page with archive list."""
-    archive_files = sorted(
-        ARCHIVE_DIR.glob("*.zip"), key=os.path.getmtime, reverse=True
-    )
-    filenames = [f.name for f in archive_files][:10]
-    return render_template("index.html", archives=filenames)
+    owned = Dataset.query.filter_by(owner_id=current_user.id)
+    shared_ids = [s.dataset_id for s in DatasetShare.query.filter_by(user_id=current_user.id)]
+    shared = Dataset.query.filter(Dataset.id.in_(shared_ids)) if shared_ids else []
+    datasets = list(owned) + list(shared)
+    datasets = datasets[-10:]
+    return render_template("index.html", datasets=datasets)
 
 @app.route("/upload", methods=["POST"])
+@login_required
 def upload():
     """Receive an image via form-data and return a ZIP of processed images."""
     file = request.files.get("image")
@@ -53,16 +120,51 @@ def upload():
     with open(archive_path, "wb") as f:
         f.write(zip_buffer.getvalue())
 
+    dataset = Dataset(filename=archive_name, owner_id=current_user.id)
+    models_db.session.add(dataset)
+    models_db.session.commit()
+
     archives = sorted(ARCHIVE_DIR.glob("*.zip"), key=os.path.getmtime, reverse=True)
     for old in archives[10:]:
+        dataset = Dataset.query.filter_by(filename=old.name).first()
+        if dataset:
+            DatasetShare.query.filter_by(dataset_id=dataset.id).delete()
+            models_db.session.delete(dataset)
+            models_db.session.commit()
         old.unlink(missing_ok=True)
 
     return redirect(url_for("index"))
 
 
 @app.route("/download/<path:filename>", methods=["GET"])
+@login_required
 def download(filename: str):
-    """Download a dataset from the archive."""
+    """Download a dataset from the archive if permitted."""
+    dataset = Dataset.query.filter_by(filename=filename).first()
+    allowed = dataset and (
+        dataset.owner_id == current_user.id
+        or DatasetShare.query.filter_by(dataset_id=dataset.id, user_id=current_user.id).first()
+    )
+    if not allowed:
+        return "Forbidden", 403
     return send_from_directory(ARCHIVE_DIR, filename, as_attachment=True)
+
+
+@app.route("/share/<int:dataset_id>", methods=["POST"])
+@login_required
+def share(dataset_id: int):
+    username = request.form.get("username")
+    user = User.query.filter_by(username=username).first()
+    dataset = Dataset.query.get(dataset_id)
+    if not user or not dataset or dataset.owner_id != current_user.id:
+        return "Not allowed", 400
+    if not DatasetShare.query.filter_by(dataset_id=dataset_id, user_id=user.id).first():
+        models_db.session.add(DatasetShare(dataset_id=dataset_id, user_id=user.id))
+        models_db.session.commit()
+    return redirect(url_for("index"))
+
+
+with app.app_context():
+    models_db.create_all()
 
 

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,27 @@
+from flask_sqlalchemy import SQLAlchemy
+from flask_login import UserMixin
+from datetime import datetime
+
+
+db = SQLAlchemy()
+
+
+class User(db.Model, UserMixin):
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(80), unique=True, nullable=False)
+    password_hash = db.Column(db.String(128), nullable=False)
+
+
+class Dataset(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    filename = db.Column(db.String(120), nullable=False)
+    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
+    owner_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    owner = db.relationship("User", backref="datasets")
+
+
+class DatasetShare(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    dataset_id = db.Column(db.Integer, db.ForeignKey("dataset.id"), nullable=False)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 flask>=3.0.0
 pillow>=10.0.0
+flask_sqlalchemy>=3.1.1
+flask_login>=0.6.3

--- a/templates/index.html
+++ b/templates/index.html
@@ -34,6 +34,11 @@
     </style>
 </head>
 <body class="glitch-edge text-center p-8 overflow-x-hidden">
+    {% if current_user.is_authenticated %}
+    <p class="mb-4">Logged in as {{ current_user.username }} | <a class="text-teal-300" href="{{ url_for('logout') }}">Logout</a></p>
+    {% else %}
+    <p class="mb-4"><a class="text-teal-300" href="{{ url_for('login') }}">Login</a> or <a class="text-teal-300" href="{{ url_for('register') }}">Register</a></p>
+    {% endif %}
     <h1 class="text-4xl font-bold mb-8 text-teal-400 tracking-wide">OneShot Dataset Prep</h1>
     <div class="flex flex-col md:flex-row justify-center md:space-x-8 space-y-8 md:space-y-0">
         <div>
@@ -43,10 +48,16 @@
                     <tr><th class="px-4 py-2 border border-gray-700">Dataset</th></tr>
                 </thead>
                 <tbody>
-                    {% for file in archives %}
+                    {% for ds in datasets %}
                     <tr>
                         <td class="border border-gray-700 px-4 py-2 text-left">
-                            <a href="{{ url_for('download', filename=file) }}" class="text-teal-300 hover:underline">{{ file }}</a>
+                            <a href="{{ url_for('download', filename=ds.filename) }}" class="text-teal-300 hover:underline">{{ ds.filename }}</a>
+                            {% if ds.owner_id == current_user.id %}
+                            <form action="{{ url_for('share', dataset_id=ds.id) }}" method="POST" class="mt-2">
+                                <input type="text" name="username" placeholder="Share with user" class="text-gray-900 p-1" required>
+                                <button type="submit" class="bg-teal-600 text-white px-2 py-1 rounded">Share</button>
+                            </form>
+                            {% endif %}
                         </td>
                     </tr>
                     {% else %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Login</title>
+    <link rel="stylesheet" href="/static/tailwind.min.css">
+</head>
+<body class="p-8 text-center">
+    <h1 class="text-2xl mb-4">Login</h1>
+    <form action="{{ url_for('login') }}" method="POST" class="space-y-4 inline-block">
+        <input type="text" name="username" placeholder="Username" required class="border p-2 w-full">
+        <input type="password" name="password" placeholder="Password" required class="border p-2 w-full">
+        <button type="submit" class="bg-blue-600 text-white px-4 py-2">Login</button>
+    </form>
+    <p class="mt-4"><a class="text-teal-300" href="{{ url_for('register') }}">Register</a></p>
+</body>
+</html>

--- a/templates/register.html
+++ b/templates/register.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Register</title>
+    <link rel="stylesheet" href="/static/tailwind.min.css">
+</head>
+<body class="p-8 text-center">
+    <h1 class="text-2xl mb-4">Register</h1>
+    <form action="{{ url_for('register') }}" method="POST" class="space-y-4 inline-block">
+        <input type="text" name="username" placeholder="Username" required class="border p-2 w-full">
+        <input type="password" name="password" placeholder="Password" required class="border p-2 w-full">
+        <button type="submit" class="bg-green-600 text-white px-4 py-2">Register</button>
+    </form>
+    <p class="mt-4"><a class="text-teal-300" href="{{ url_for('login') }}">Login</a></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Flask-SQLAlchemy models for users, datasets and shares
- integrate login/registration/logout and dataset sharing routes
- protect dataset access with Flask-Login
- show login state and sharing UI in index template

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e4a1d4468833385c00cf53de58a6c