### PR TITLE
Add dataset deletion

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -164,6 +164,22 @@ def share(dataset_id: int):
     return redirect(url_for("index"))
 
 
+@app.route("/delete/<int:dataset_id>", methods=["POST"])
+@login_required
+def delete_dataset(dataset_id: int):
+    """Remove a dataset if the current user is the owner."""
+    dataset = Dataset.query.get(dataset_id)
+    if not dataset or dataset.owner_id != current_user.id:
+        return "Forbidden", 403
+
+    path = ARCHIVE_DIR / dataset.filename
+    path.unlink(missing_ok=True)
+    DatasetShare.query.filter_by(dataset_id=dataset_id).delete()
+    models_db.session.delete(dataset)
+    models_db.session.commit()
+    return redirect(url_for("index"))
+
+
 @app.route("/admin/users", methods=["GET", "POST"])
 @login_required
 def admin_users():

--- a/templates/index.html
+++ b/templates/index.html
@@ -61,6 +61,9 @@
                                 <input type="text" name="username" placeholder="Share with user" class="text-gray-900 p-1" required>
                                 <button type="submit" class="bg-teal-600 text-white px-2 py-1 rounded">Share</button>
                             </form>
+                            <form action="{{ url_for('delete_dataset', dataset_id=ds.id) }}" method="POST" class="mt-2">
+                                <button type="submit" class="bg-red-600 text-white px-2 py-1 rounded">Delete</button>
+                            </form>
                             {% endif %}
                         </td>
                     </tr>


### PR DESCRIPTION
## Summary
- allow dataset owners to delete archives
- show a delete button for owner-only actions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e7070864883338a239bc9b0228994