### PR TITLE
Add registration toggle in admin panel

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -26,3 +26,30 @@ class DatasetShare(db.Model):
     dataset_id = db.Column(db.Integer, db.ForeignKey("dataset.id"), nullable=False)
     user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
 
+
+class Setting(db.Model):
+    """Key/value store for simple configuration flags."""
+
+    id = db.Column(db.Integer, primary_key=True)
+    key = db.Column(db.String(80), unique=True, nullable=False)
+    bool_value = db.Column(db.Boolean, default=True)
+
+    @classmethod
+    def get_bool(cls, key: str, default: bool = True) -> bool:
+        setting = cls.query.filter_by(key=key).first()
+        if setting is None:
+            setting = cls(key=key, bool_value=default)
+            db.session.add(setting)
+            db.session.commit()
+        return bool(setting.bool_value)
+
+    @classmethod
+    def set_bool(cls, key: str, value: bool) -> None:
+        setting = cls.query.filter_by(key=key).first()
+        if setting is None:
+            setting = cls(key=key, bool_value=value)
+            db.session.add(setting)
+        else:
+            setting.bool_value = value
+        db.session.commit()
+

--- a/templates/admin_users.html
+++ b/templates/admin_users.html
@@ -36,6 +36,14 @@
 <body class="glitch-edge text-center p-8 overflow-x-hidden">
     <h1 class="text-4xl font-bold mb-4 text-teal-400 tracking-wide">User Administration</h1>
     <p class="mb-6"><a class="text-teal-300" href="{{ url_for('index') }}">Home</a></p>
+    <form action="{{ url_for('admin_users') }}" method="POST" class="mb-6 inline-block bg-gray-800 bg-opacity-50 p-2 rounded">
+        <input type="hidden" name="action" value="toggle_registration">
+        <label class="inline-flex items-center">
+            <input type="checkbox" name="registration_enabled" class="mr-2" {% if registration_enabled %}checked{% endif %}>
+            <span>Enable public registration</span>
+        </label>
+        <button type="submit" class="ml-4 bg-blue-600 text-white px-2 py-1 rounded">Save</button>
+    </form>
     <table class="table-auto mx-auto mb-8 border-collapse bg-gray-800 bg-opacity-50 rounded">
         <thead>
             <tr><th class="px-4 py-2 border border-gray-700">Username</th><th class="px-4 py-2 border border-gray-700">Action</th></tr>
@@ -55,6 +63,7 @@
     </table>
     <h2 class="text-2xl font-semibold mb-2 text-pink-400">Create User</h2>
     <form action="{{ url_for('admin_users') }}" method="POST" class="space-y-2 inline-block bg-gray-800 bg-opacity-50 p-4 rounded">
+        <input type="hidden" name="action" value="create_user">
         <input type="text" name="username" placeholder="Username" required class="border border-gray-700 p-2 w-full bg-gray-900 text-gray-200">
         <input type="password" name="password" placeholder="Password" required class="border border-gray-700 p-2 w-full bg-gray-900 text-gray-200">
         <button type="submit" class="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded transition-colors">Create</button>

--- a/templates/index.html
+++ b/templates/index.html
@@ -41,7 +41,7 @@
     {% endif %}
     <a class="text-teal-300" href="{{ url_for('logout') }}">Logout</a></p>
     {% else %}
-    <p class="mb-4"><a class="text-teal-300" href="{{ url_for('login') }}">Login</a> or <a class="text-teal-300" href="{{ url_for('register') }}">Register</a></p>
+    <p class="mb-4"><a class="text-teal-300" href="{{ url_for('login') }}">Login</a>{% if registration_enabled %} or <a class="text-teal-300" href="{{ url_for('register') }}">Register</a>{% endif %}</p>
     {% endif %}
     <h1 class="text-4xl font-bold mb-8 text-teal-400 tracking-wide">OneShot Dataset Prep</h1>
     <div class="flex flex-col md:flex-row justify-center md:space-x-8 space-y-8 md:space-y-0">

--- a/templates/login.html
+++ b/templates/login.html
@@ -12,6 +12,8 @@
         <input type="password" name="password" placeholder="Password" required class="border p-2 w-full">
         <button type="submit" class="bg-blue-600 text-white px-4 py-2">Login</button>
     </form>
+    {% if registration_enabled %}
     <p class="mt-4"><a class="text-teal-300" href="{{ url_for('register') }}">Register</a></p>
+    {% endif %}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add new Setting model for simple key/value flags
- block registration route if disabled
- expose registration toggle on the user admin page
- inject setting into templates and hide register link accordingly

## Testing
- `pip install -q -r requirements.txt`
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686eb4da87648333979cd5de156cb90a