### PR TITLE
Remove upload button and add user-based zip names

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -19,7 +19,8 @@ from io import BytesIO
 import zipfile
 from pathlib import Path
 import os
-import time
+import random
+from datetime import datetime
 
 from .processing import crop_and_flip
 
@@ -122,7 +123,9 @@ def upload():
 
     zip_buffer.seek(0)
 
-    archive_name = f"{base_name}_{int(time.time())}.zip"
+    timestamp = datetime.utcnow().strftime("%Y%m%d-%H%M%S")
+    random_part = random.randint(0, 99999)
+    archive_name = f"{current_user.username}_{timestamp}_{random_part:05}.zip"
     archive_path = ARCHIVE_DIR / archive_name
     with open(archive_path, "wb") as f:
         f.write(zip_buffer.getvalue())

--- a/templates/index.html
+++ b/templates/index.html
@@ -78,7 +78,6 @@
                 Drop image here or click to select
                 <input id="file-input" type="file" name="image" accept="image/*" required class="hidden">
             </div>
-            <button type="submit" class="bg-pink-600 hover:bg-pink-700 text-white px-4 py-2 rounded transition-colors">Upload & Generate ZIP</button>
         </form>
         <script>
         document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- remove the unused submit button from the upload form
- generate archive names based on username and timestamp with a random number

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687009c5ec60833389c3010df55993e6