### PR TITLE
Add team archives and management

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ directed to the upload page.
    user by entering their username. Shared datasets appear in both users'
    archive list.
 4. **Deletion** – Each user can delete the datasets they own at any time.
+5. **Teams** – A user can create a team and invite other members. Uploads may be
+   stored in a team archive which is shared by all members.
 
 ## Admin view
 
@@ -28,6 +30,13 @@ Administrators have two ways to manage the system:
   be toggled.
 * The command `./maintainer.sh create-admin <user> <pass>` can create an initial
   admin account on the command line.
+
+## Team management
+
+The creator of a team becomes its head and can invite members from the
+"Manage Team" page. Every team has its own archive directory and keeps the most
+recent ten uploads (configurable via the `ARCHIVE_LIMIT_TEAM` environment
+variable).
 
 ## Setup using `maintainer.sh`
 

--- a/app/models.py
+++ b/app/models.py
@@ -13,12 +13,27 @@ class User(db.Model, UserMixin):
     is_admin = db.Column(db.Boolean, default=False)
 
 
+class Team(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(120), nullable=False)
+    owner_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    owner = db.relationship("User", backref="owned_teams")
+
+
+class TeamMember(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    team_id = db.Column(db.Integer, db.ForeignKey("team.id"), nullable=False)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+
+
 class Dataset(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     filename = db.Column(db.String(120), nullable=False)
     timestamp = db.Column(db.DateTime, default=datetime.utcnow)
     owner_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
     owner = db.relationship("User", backref="datasets")
+    team_id = db.Column(db.Integer, db.ForeignKey("team.id"))
+    team = db.relationship("Team", backref="datasets")
 
 
 class DatasetShare(db.Model):

--- a/templates/create_team.html
+++ b/templates/create_team.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Create Team</title>
+    <link rel="stylesheet" href="/static/tailwind.min.css">
+</head>
+<body class="text-center p-8">
+    <h1 class="text-3xl mb-4">Create Team</h1>
+    <form action="{{ url_for('create_team') }}" method="POST" class="space-y-4 inline-block">
+        <input type="text" name="name" placeholder="Team name" required class="p-2 border">
+        <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Create</button>
+    </form>
+    <p class="mt-4"><a class="text-teal-300" href="{{ url_for('index') }}">Back</a></p>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -31,6 +31,7 @@
     {% if current_user.is_admin %}
     <a class="text-teal-300" href="{{ url_for('admin_users') }}">User Admin</a> |
     {% endif %}
+    <a class="text-teal-300" href="{{ url_for('create_team') }}">Create Team</a> |
     <a class="text-teal-300" href="{{ url_for('logout') }}">Logout</a></p>
     {% else %}
     <p class="mb-4"><a class="text-teal-300" href="{{ url_for('login') }}">Login</a>{% if registration_enabled %} or <a class="text-teal-300" href="{{ url_for('register') }}">Register</a>{% endif %}</p>
@@ -41,6 +42,12 @@
                 Drop image here or click to select
                 <input id="file-input" type="file" name="image" accept="image/*" required class="hidden">
             </div>
+            <select name="team_id" class="mb-4 bg-gray-900 text-gray-200 border border-gray-700 p-1">
+                <option value="">Personal Space</option>
+                {% for t in teams %}
+                <option value="{{ t.id }}">{{ t.name }}</option>
+                {% endfor %}
+            </select>
             <div id="progress-container" class="hidden mt-4">
                 <div class="w-full bg-gray-700 rounded h-4">
                     <div id="progress-bar" class="bg-teal-500 h-4 rounded" style="width:0%"></div>
@@ -59,6 +66,7 @@
                     <tr>
                         <td class="border border-gray-700 px-4 py-2 text-left">
                             <a href="{{ url_for('download', filename=ds.filename) }}" class="text-teal-300 hover:underline">{{ ds.filename }}</a>
+                            {% if ds.team_id %}<span class="text-xs ml-2 text-gray-400">(Team {{ ds.team.name }})</span>{% endif %}
                             {% if ds.owner_id == current_user.id %}
                             <form action="{{ url_for('share', dataset_id=ds.id) }}" method="POST" class="mt-2">
                                 <input type="text" name="username" placeholder="Share with user" class="text-gray-900 p-1" required>
@@ -123,6 +131,10 @@
                 const xhr = new XMLHttpRequest();
                 const data = new FormData();
                 data.append('image', file);
+                const teamSelect = document.querySelector('select[name="team_id"]');
+                if (teamSelect) {
+                    data.append('team_id', teamSelect.value);
+                }
                 xhr.open('POST', '/upload');
                 xhr.withCredentials = true;
 

--- a/templates/manage_team.html
+++ b/templates/manage_team.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Manage Team</title>
+    <link rel="stylesheet" href="/static/tailwind.min.css">
+</head>
+<body class="text-center p-8">
+    <h1 class="text-3xl mb-4">Manage {{ team.name }}</h1>
+    <form action="{{ url_for('add_member', team_id=team.id) }}" method="POST" class="space-y-2 inline-block mb-6">
+        <input type="text" name="username" placeholder="Add member by username" required class="p-2 border">
+        <button type="submit" class="bg-green-600 text-white px-3 py-1 rounded">Add</button>
+    </form>
+    <ul class="mb-4">
+    {% for m in members %}
+        <li>{{ m.username }}</li>
+    {% endfor %}
+    </ul>
+    <p><a class="text-teal-300" href="{{ url_for('index') }}">Back</a></p>
+</body>
+</html>

--- a/tests/test_team.py
+++ b/tests/test_team.py
@@ -1,0 +1,31 @@
+from flask import Flask
+from app.models import db, User, Team, TeamMember, Dataset
+
+
+def setup_app():
+    app = Flask(__name__)
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+    db.init_app(app)
+    with app.app_context():
+        db.create_all()
+    return app
+
+
+def test_team_creation_and_dataset():
+    app = setup_app()
+    with app.app_context():
+        user = User(username='u', password_hash='x')
+        db.session.add(user)
+        db.session.commit()
+        team = Team(name='t', owner_id=user.id)
+        db.session.add(team)
+        db.session.commit()
+        member = TeamMember(team_id=team.id, user_id=user.id)
+        db.session.add(member)
+        ds = Dataset(filename='a.zip', owner_id=user.id, team_id=team.id)
+        db.session.add(ds)
+        db.session.commit()
+        assert Team.query.count() == 1
+        assert TeamMember.query.count() == 1
+        assert Dataset.query.filter_by(team_id=team.id).first() is not None


### PR DESCRIPTION
## Summary
- add `Team` and `TeamMember` models and link datasets to teams
- implement team creation and member management routes
- store team datasets under `archives/team_<id>/`
- update cleanup logic for per-user and per-team limits
- extend UI with team selector and links
- document team feature in README
- add tests for team creation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68701a3e310c83339752f541e6f7067a