### PR TITLE
Add DB migration step to updater

### DIFF
--- a/maintainer.sh
+++ b/maintainer.sh
@@ -28,6 +28,9 @@ update() {
     fi
     git -C "$APP_DIR" pull
     "$VENV/bin/pip" install -r "$APP_DIR/requirements.txt"
+    if [ -f "$APP_DIR/migrate_db.py" ]; then
+        "$VENV/bin/python" "$APP_DIR/migrate_db.py"
+    fi
     if [ $was_active -eq 1 ]; then
         systemctl restart oneshot.service
     fi

--- a/migrate_db.py
+++ b/migrate_db.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+from app.models import db
+from app.main import app
+from sqlalchemy import inspect, text
+
+
+def run_migrations() -> None:
+    """Apply pending SQLite schema updates."""
+    with app.app_context():
+        inspector = inspect(db.engine)
+        cols = [c["name"] for c in inspector.get_columns("dataset")]
+        if "team_id" not in cols:
+            db.engine.execute(text("ALTER TABLE dataset ADD COLUMN team_id INTEGER"))
+        db.create_all()
+
+
+if __name__ == "__main__":
+    run_migrations()


### PR DESCRIPTION
## Summary
- add a lightweight migration script
- call migration script from `maintainer.sh update`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68701d9774d08333821c0a21dc239c99