### PR TITLE
Add team edit and archive links

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -84,6 +84,22 @@
                 </tbody>
             </table>
         </div>
+        <div>
+            <h2 class="text-2xl font-semibold mt-8 mb-4 text-pink-400">Teams</h2>
+            <ul>
+            {% for t in teams %}
+                <li class="mb-2">
+                    <span class="font-semibold">{{ t.name }}</span>
+                    <a class="ml-2 text-teal-300" href="{{ url_for('team_archive', team_id=t.id) }}">Team Archive</a>
+                    {% if t.owner_id == current_user.id %}
+                    <a class="ml-2 text-teal-300" href="{{ url_for('manage_team', team_id=t.id) }}">Team bearbeiten</a>
+                    {% endif %}
+                </li>
+            {% else %}
+                <li>No teams</li>
+            {% endfor %}
+            </ul>
+        </div>
         <script>
         function startMatrix(canvas) {
             const ctx = canvas.getContext('2d');

--- a/templates/manage_team.html
+++ b/templates/manage_team.html
@@ -13,9 +13,19 @@
     </form>
     <ul class="mb-4">
     {% for m in members %}
-        <li>{{ m.username }}</li>
+        <li>
+            {{ m.username }}
+            {% if m.id != team.owner_id %}
+            <form action="{{ url_for('remove_member', team_id=team.id, user_id=m.id) }}" method="POST" class="inline ml-2">
+                <button type="submit" class="bg-red-600 text-white px-2 py-1 rounded">Remove</button>
+            </form>
+            {% endif %}
+        </li>
     {% endfor %}
     </ul>
+    <form action="{{ url_for('delete_team', team_id=team.id) }}" method="POST" class="mb-4">
+        <button type="submit" class="bg-red-700 text-white px-4 py-2 rounded">Delete Team</button>
+    </form>
     <p><a class="text-teal-300" href="{{ url_for('index') }}">Back</a></p>
 </body>
 </html>

--- a/templates/team_archive.html
+++ b/templates/team_archive.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Team Archive</title>
+    <link rel="stylesheet" href="/static/tailwind.min.css">
+</head>
+<body class="text-center p-8">
+    <h1 class="text-3xl mb-4">{{ team.name }} Archive</h1>
+    <table class="table-auto mx-auto border-collapse bg-gray-800 bg-opacity-50 rounded">
+        <thead>
+            <tr><th class="px-4 py-2 border border-gray-700">Dataset</th></tr>
+        </thead>
+        <tbody>
+        {% for ds in datasets %}
+            <tr>
+                <td class="border border-gray-700 px-4 py-2 text-left">
+                    <a href="{{ url_for('download', filename=ds.filename) }}" class="text-teal-300 hover:underline">{{ ds.filename }}</a>
+                </td>
+            </tr>
+        {% else %}
+            <tr><td class="border border-gray-700 px-4 py-2">No datasets</td></tr>
+        {% endfor %}
+        </tbody>
+    </table>
+    <p class="mt-4"><a class="text-teal-300" href="{{ url_for('index') }}">Back</a></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- allow removing members and deleting teams
- add new team archive route and page
- show team links on the main page
- add remove and delete actions on team management page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68702092d39083338d0a5ed63c600fd2