### PR TITLE
Fix team dataset download permissions

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -279,6 +279,10 @@ def download(filename: str):
     allowed = dataset and (
         dataset.owner_id == current_user.id
         or DatasetShare.query.filter_by(dataset_id=dataset.id, user_id=current_user.id).first()
+        or (
+            dataset.team_id
+            and TeamMember.query.filter_by(team_id=dataset.team_id, user_id=current_user.id).first()
+        )
     )
     if not allowed:
         return "Forbidden", 403

--- a/tests/test_team.py
+++ b/tests/test_team.py
@@ -29,3 +29,44 @@ def test_team_creation_and_dataset():
         assert Team.query.count() == 1
         assert TeamMember.query.count() == 1
         assert Dataset.query.filter_by(team_id=team.id).first() is not None
+
+
+def test_team_member_can_download(tmp_path, monkeypatch):
+    from werkzeug.security import generate_password_hash
+    from app import main
+
+    monkeypatch.setattr(main, 'ARCHIVE_DIR', tmp_path)
+    main.app.config['TESTING'] = True
+    main.app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+
+    with main.app.app_context():
+        main.models_db.drop_all()
+        main.models_db.create_all()
+
+        owner = main.User(username='owner', password_hash=generate_password_hash('a'))
+        member = main.User(username='member', password_hash=generate_password_hash('b'))
+        main.models_db.session.add_all([owner, member])
+        main.models_db.session.commit()
+
+        team = main.Team(name='t', owner_id=owner.id)
+        main.models_db.session.add(team)
+        main.models_db.session.commit()
+
+        main.models_db.session.add_all([
+            main.TeamMember(team_id=team.id, user_id=owner.id),
+            main.TeamMember(team_id=team.id, user_id=member.id),
+        ])
+        ds = main.Dataset(filename='x.zip', owner_id=owner.id, team_id=team.id)
+        main.models_db.session.add(ds)
+        main.models_db.session.commit()
+        team_id = team.id
+        filename = ds.filename
+
+    team_dir = tmp_path / f'team_{team_id}'
+    team_dir.mkdir(parents=True, exist_ok=True)
+    (team_dir / filename).write_bytes(b'data')
+
+    client = main.app.test_client()
+    client.post('/login', data={'username': 'member', 'password': 'b'})
+    resp = client.get(f'/download/{filename}')
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- allow team members to download datasets stored in their team archive
- test that team members can download team datasets

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6870229934e08333ab2681018d6fc964