### PR TITLE
Implement team creation permission

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -121,6 +121,8 @@ def logout():
 @app.route("/teams/create", methods=["GET", "POST"])
 @login_required
 def create_team():
+    if not (current_user.is_admin or current_user.can_create_team):
+        return "Forbidden", 403
     if request.method == "POST":
         name = request.form.get("name")
         if not name:
@@ -344,6 +346,14 @@ def admin_users():
         elif action == "toggle_registration":
             enabled = request.form.get("registration_enabled") == "on"
             Setting.set_bool("registration_enabled", enabled)
+            return redirect(url_for("admin_users"))
+        elif action == "update_perms":
+            user_id = int(request.form.get("user_id", 0))
+            allow = request.form.get("can_create_team") == "on"
+            user = User.query.get(user_id)
+            if user:
+                user.can_create_team = allow
+                models_db.session.commit()
             return redirect(url_for("admin_users"))
     users = User.query.all()
     reg_enabled = Setting.get_bool("registration_enabled", True)

--- a/app/models.py
+++ b/app/models.py
@@ -11,6 +11,7 @@ class User(db.Model, UserMixin):
     username = db.Column(db.String(80), unique=True, nullable=False)
     password_hash = db.Column(db.String(128), nullable=False)
     is_admin = db.Column(db.Boolean, default=False)
+    can_create_team = db.Column(db.Boolean, default=False)
 
 
 class Team(db.Model):

--- a/migrate_db.py
+++ b/migrate_db.py
@@ -14,6 +14,12 @@ def run_migrations() -> None:
                 text("ALTER TABLE dataset ADD COLUMN team_id INTEGER")
             )
             db.session.commit()
+        cols = [c["name"] for c in inspector.get_columns("user")]
+        if "can_create_team" not in cols:
+            db.session.execute(
+                text("ALTER TABLE user ADD COLUMN can_create_team BOOLEAN DEFAULT 0")
+            )
+            db.session.commit()
         db.create_all()
 
 

--- a/templates/admin_users.html
+++ b/templates/admin_users.html
@@ -37,12 +37,26 @@
     </form>
     <table class="table-auto mx-auto mb-8 border-collapse bg-gray-800 bg-opacity-50 rounded">
         <thead>
-            <tr><th class="px-4 py-2 border border-gray-700">Username</th><th class="px-4 py-2 border border-gray-700">Action</th></tr>
+            <tr>
+                <th class="px-4 py-2 border border-gray-700">Username</th>
+                <th class="px-4 py-2 border border-gray-700">Can Create Team</th>
+                <th class="px-4 py-2 border border-gray-700">Action</th>
+            </tr>
         </thead>
         <tbody>
         {% for u in users %}
             <tr>
                 <td class="border border-gray-700 px-4 py-2">{{ u.username }}</td>
+                <td class="border border-gray-700 px-4 py-2">
+                    <form action="{{ url_for('admin_users') }}" method="POST">
+                        <input type="hidden" name="action" value="update_perms">
+                        <input type="hidden" name="user_id" value="{{ u.id }}">
+                        <label class="inline-flex items-center">
+                            <input type="checkbox" name="can_create_team" class="mr-2" {% if u.can_create_team %}checked{% endif %} onchange="this.form.submit()">
+                            <span></span>
+                        </label>
+                    </form>
+                </td>
                 <td class="border border-gray-700 px-4 py-2">
                     <form action="{{ url_for('admin_delete_user', user_id=u.id) }}" method="POST">
                         <button type="submit" class="bg-red-600 text-white px-2 py-1 rounded">Delete</button>

--- a/templates/index.html
+++ b/templates/index.html
@@ -31,7 +31,9 @@
     {% if current_user.is_admin %}
     <a class="text-teal-300" href="{{ url_for('admin_users') }}">User Admin</a> |
     {% endif %}
+    {% if current_user.is_admin or current_user.can_create_team %}
     <a class="text-teal-300" href="{{ url_for('create_team') }}">Create Team</a> |
+    {% endif %}
     <a class="text-teal-300" href="{{ url_for('logout') }}">Logout</a></p>
     {% else %}
     <p class="mb-4"><a class="text-teal-300" href="{{ url_for('login') }}">Login</a>{% if registration_enabled %} or <a class="text-teal-300" href="{{ url_for('register') }}">Register</a>{% endif %}</p>


### PR DESCRIPTION
## Summary
- add `can_create_team` flag to `User`
- extend migration script for new column
- restrict team creation to admin or users with permission
- allow admin to toggle permission in user admin page
- show "Create Team" link only for authorized users

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687024767dfc8333baaf5d4ef06a1c6e