### PR TITLE
Implement quota based storage with team-only sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,16 @@ management. All binary dependencies are installed via the supplied
    create accounts using the maintainer script. After logging in they are
 directed to the upload page.
 2. **Uploading** – Drag and drop an image onto the form. The server generates 14
-   cropped and flipped images, stores them as a ZIP file and keeps the ten most
-   recent archives for each user. The page refreshes after processing so the ZIP
-   can be downloaded from the archive list.
-3. **Sharing** – The owner of an archive can share it with another registered
-   user by entering their username. Shared datasets appear in both users'
-   archive list.
-4. **Deletion** – Each user can delete the datasets they own at any time.
-5. **Teams** – A user can create a team and invite other members. Uploads may be
-   stored in a team archive which is shared by all members.
+   cropped and flipped images and stores them as a ZIP file in the user's
+   personal directory or the selected team directory. Each user may keep up to
+   ten personal datasets while every team can store fifty datasets. The page
+   refreshes after processing so the ZIP can be downloaded from the archive
+   list.
+3. **Deletion** – Users remove old datasets themselves once the quota is
+   reached.
+4. **Teams** – A user can create a team and invite other members. Uploads may be
+   stored in a team archive which is shared by all members. Personal dataset
+   sharing has been removed.
 
 ## Admin view
 
@@ -34,9 +35,8 @@ Administrators have two ways to manage the system:
 ## Team management
 
 The creator of a team becomes its head and can invite members from the
-"Manage Team" page. Every team has its own archive directory and keeps the most
-recent ten uploads (configurable via the `ARCHIVE_LIMIT_TEAM` environment
-variable).
+"Manage Team" page. Every team has its own archive directory and may store up to
+fifty uploads (configurable via the `ARCHIVE_LIMIT_TEAM` environment variable).
 
 ## Setup using `maintainer.sh`
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -28,13 +28,19 @@
     <h1 class="text-4xl font-bold mb-8 text-teal-400 tracking-wide">OneShot Dataset Prep</h1>
     {% if current_user.is_authenticated %}
     <p class="mb-4">Logged in as {{ current_user.username }} |
-    {% if current_user.is_admin %}
-    <a class="text-teal-300" href="{{ url_for('admin_users') }}">User Admin</a> |
-    {% endif %}
-    {% if current_user.is_admin or current_user.can_create_team %}
-    <a class="text-teal-300" href="{{ url_for('create_team') }}">Create Team</a> |
-    {% endif %}
-    <a class="text-teal-300" href="{{ url_for('logout') }}">Logout</a></p>
+        {% if current_user.is_admin %}
+        <a class="text-teal-300" href="{{ url_for('admin_users') }}">User Admin</a> |
+        {% endif %}
+        {% if current_user.is_admin or current_user.can_create_team %}
+        <a class="text-teal-300" href="{{ url_for('create_team') }}">Create Team</a> |
+        {% endif %}
+        <a class="text-teal-300" href="{{ url_for('logout') }}">Logout</a></p>
+    <p class="mb-4">
+        Personal quota: {{ personal_count }}/{{ personal_limit }}<br>
+        {% for t, c in team_data %}
+        Team {{ t.name }}: {{ c }}/{{ team_limit }}{% if not loop.last %}<br>{% endif %}
+        {% endfor %}
+    </p>
     {% else %}
     <p class="mb-4"><a class="text-teal-300" href="{{ url_for('login') }}">Login</a>{% if registration_enabled %} or <a class="text-teal-300" href="{{ url_for('register') }}">Register</a>{% endif %}</p>
     {% endif %}
@@ -70,10 +76,6 @@
                             <a href="{{ url_for('download', filename=ds.filename) }}" class="text-teal-300 hover:underline">{{ ds.filename }}</a>
                             {% if ds.team_id %}<span class="text-xs ml-2 text-gray-400">(Team {{ ds.team.name }})</span>{% endif %}
                             {% if ds.owner_id == current_user.id %}
-                            <form action="{{ url_for('share', dataset_id=ds.id) }}" method="POST" class="mt-2">
-                                <input type="text" name="username" placeholder="Share with user" class="text-gray-900 p-1" required>
-                                <button type="submit" class="bg-teal-600 text-white px-2 py-1 rounded">Share</button>
-                            </form>
                             <form action="{{ url_for('delete_dataset', dataset_id=ds.id) }}" method="POST" class="mt-2">
                                 <button type="submit" class="bg-red-600 text-white px-2 py-1 rounded">Delete</button>
                             </form>

--- a/tests/test_user_dir.py
+++ b/tests/test_user_dir.py
@@ -1,0 +1,39 @@
+from io import BytesIO
+from PIL import Image
+from werkzeug.security import generate_password_hash
+from app import main
+
+
+def setup_user(tmp_path, monkeypatch):
+    monkeypatch.setattr(main, 'ARCHIVE_DIR', tmp_path)
+    monkeypatch.setattr(main, 'ARCHIVE_LIMIT_USER', 1)
+    main.app.config['TESTING'] = True
+    main.app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    with main.app.app_context():
+        main.models_db.drop_all()
+        main.models_db.create_all()
+        user = main.User(username='u', password_hash=generate_password_hash('a'))
+        main.models_db.session.add(user)
+        main.models_db.session.commit()
+        return user.id
+
+
+def test_user_directory_and_quota(tmp_path, monkeypatch):
+    user_id = setup_user(tmp_path, monkeypatch)
+    client = main.app.test_client()
+    client.post('/login', data={'username': 'u', 'password': 'a'})
+
+    img = Image.new('RGB', (10, 10), color='red')
+    buf = BytesIO()
+    img.save(buf, format='PNG')
+    buf.seek(0)
+
+    resp1 = client.post('/upload', data={'image': (buf, 'a.png')}, content_type='multipart/form-data')
+    assert resp1.status_code == 302
+    buf2 = BytesIO()
+    img.save(buf2, format='PNG')
+    buf2.seek(0)
+    resp2 = client.post('/upload', data={'image': (buf2, 'b.png')}, content_type='multipart/form-data')
+    assert resp2.status_code == 400
+    user_dir = tmp_path / f'user_{user_id}'
+    assert any(user_dir.iterdir())


### PR DESCRIPTION
## Summary
- enforce dataset quotas for personal and team uploads
- store user uploads in per-user directories
- remove personal share functionality and update interface
- display remaining quota on the index page
- document new behaviour
- add tests for user quota logic

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687027088cd08333a75274b96a6d3f86