### PR TITLE
Move archive limits to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,8 @@ directed to the upload page.
 2. **Uploading** – Drag and drop an image onto the form. The server generates 14
    cropped and flipped images and stores them as a ZIP file in either the user's
    archive directory (`archives/user_<id>`) or the selected team directory
-   (`archives/team_<id>`). Each user may keep up to ten personal datasets
-   (configurable via `ARCHIVE_LIMIT_USER`) while every team can store fifty
-   (`ARCHIVE_LIMIT_TEAM`). The page refreshes after processing so the ZIP can be
+   (`archives/team_<id>`). Each user may keep up to ten personal datasets while
+   every team can store fifty by default. The page refreshes after processing so the ZIP can be
    downloaded from the archive list.
 3. **Deletion** – Users remove old datasets themselves once the quota is
    reached.
@@ -32,15 +31,17 @@ Administrators have two ways to manage the system:
   be toggled.
 * The command `./maintainer.sh create-admin <user> <pass>` can create an initial
   admin account on the command line.
+* Adjust dataset quotas by editing `config.json` and setting
+  `"archive_limit_user"` and `"archive_limit_team"`.
 
 ## Team management
 
 The creator of a team becomes its head and can invite members from the
 "Manage Team" page. Only admins or users granted the `can_create_team`
 permission can start new teams. Archives are stored under
-`archives/team_<id>` and may hold up to fifty uploads by default (controlled by
-`ARCHIVE_LIMIT_TEAM`). Personal uploads are saved in `archives/user_<id>` and
-are limited via `ARCHIVE_LIMIT_USER`.
+`archives/team_<id>` and may hold up to fifty uploads by default. Personal
+uploads are saved in `archives/user_<id>` and share the same ten-file limit as
+the personal archive.
 
 ## Setup using `maintainer.sh`
 

--- a/app/main.py
+++ b/app/main.py
@@ -22,6 +22,7 @@ import os
 import random
 from datetime import datetime
 import shutil
+import json
 
 from .processing import crop_and_flip
 
@@ -62,8 +63,26 @@ def load_user(user_id):
 ARCHIVE_DIR = Path(__file__).resolve().parent.parent / "archives"
 ARCHIVE_DIR.mkdir(exist_ok=True)
 
-ARCHIVE_LIMIT_USER = int(os.getenv("ARCHIVE_LIMIT_USER", "10"))
-ARCHIVE_LIMIT_TEAM = int(os.getenv("ARCHIVE_LIMIT_TEAM", "50"))
+
+def _load_config() -> dict:
+    """Read ``config.json`` from the project root if available."""
+    path = Path(__file__).resolve().parent.parent / "config.json"
+    if path.exists():
+        try:
+            with path.open() as f:
+                return json.load(f)
+        except Exception:
+            pass
+    return {}
+
+
+_config = _load_config()
+ARCHIVE_LIMIT_USER = int(
+    _config.get("archive_limit_user", os.getenv("ARCHIVE_LIMIT_USER", "10"))
+)
+ARCHIVE_LIMIT_TEAM = int(
+    _config.get("archive_limit_team", os.getenv("ARCHIVE_LIMIT_TEAM", "50"))
+)
 
 
 @app.route("/register", methods=["GET", "POST"])

--- a/config.json
+++ b/config.json
@@ -1,3 +1,5 @@
 {
-  "port": 7860
+  "port": 7860,
+  "archive_limit_user": 10,
+  "archive_limit_team": 50
 }


### PR DESCRIPTION
## Summary
- move dataset quota values from environment variables to `config.json`
- load the new `archive_limit_*` keys in `app/main.py`
- document quota configuration in admin section of README and remove env var references from user section

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68702e117d988333910a8b69f7eb5da1