### PR TITLE
Add preview gallery feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,14 @@ directed to the upload page.
    (`archives/team_<id>`). Each user may keep up to ten personal datasets while
    every team can store fifty by default. The page refreshes after processing so the ZIP can be
    downloaded from the archive list.
-3. **Deletion** – Users remove old datasets themselves once the quota is
+3. **Previewing** – Every upload also stores the generated images under
+   `archives/<user|team>_<id>/<archive_name>` without the `.zip` suffix.
+   Opening `/preview/<dataset_id>` displays these images in a small gallery.
+4. **Deletion** – Users remove old datasets themselves once the quota is
    reached.
-4. **Teams** – Team creation is restricted to administrators or users with the
+5. **Teams** – Team creation is restricted to administrators or users with the
    `can_create_team` permission. Uploads may be stored in a shared team archive
-   that all members can access. 
+   that all members can access.
 
 ## Admin view
 

--- a/templates/preview.html
+++ b/templates/preview.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Preview</title>
+    <link rel="stylesheet" href="/static/tailwind.min.css">
+    <style>
+        body {
+            background: #0d0d0d;
+            color: #e0e0e0;
+            font-family: 'Roboto', sans-serif;
+        }
+        .grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+            gap: 10px;
+        }
+        img {
+            max-width: 100%;
+            border: 1px solid #333;
+        }
+    </style>
+</head>
+<body class="p-6 text-center">
+    <h1 class="text-3xl mb-4">Preview {{ dataset.filename }}</h1>
+    <div class="grid">
+        {% for f in files %}
+        <img src="{{ url_for('preview', dataset_id=dataset.id, file=f) }}" alt="{{ f }}">
+        {% endfor %}
+    </div>
+    <p class="mt-4"><a class="text-teal-300" href="{{ url_for('team_archive', team_id=dataset.team_id) if dataset.team_id else url_for('index') }}">Back</a></p>
+</body>
+</html>

--- a/templates/team_archive.html
+++ b/templates/team_archive.html
@@ -28,7 +28,10 @@
     <h1 class="text-3xl mb-4">{{ team.name }} Archive</h1>
     <table class="table-auto mx-auto border-collapse bg-gray-800 bg-opacity-50 rounded">
         <thead>
-            <tr><th class="px-4 py-2 border border-gray-700">Dataset</th></tr>
+            <tr>
+                <th class="px-4 py-2 border border-gray-700">Dataset</th>
+                <th class="px-4 py-2 border border-gray-700">Actions</th>
+            </tr>
         </thead>
         <tbody>
         {% for ds in datasets %}
@@ -36,9 +39,12 @@
                 <td class="border border-gray-700 px-4 py-2 text-left">
                     <a href="{{ url_for('download', filename=ds.filename) }}" class="text-teal-300 hover:underline">{{ ds.filename }}</a>
                 </td>
+                <td class="border border-gray-700 px-4 py-2">
+                    <a class="text-teal-300 hover:underline" href="{{ url_for('preview', dataset_id=ds.id) }}">Preview</a>
+                </td>
             </tr>
         {% else %}
-            <tr><td class="border border-gray-700 px-4 py-2">No datasets</td></tr>
+            <tr><td class="border border-gray-700 px-4 py-2" colspan="2">No datasets</td></tr>
         {% endfor %}
         </tbody>
     </table>

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -1,0 +1,92 @@
+import sys
+from pathlib import Path
+from io import BytesIO
+from PIL import Image
+from werkzeug.security import generate_password_hash
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from app import main
+
+
+def setup_env(tmp_path, monkeypatch):
+    monkeypatch.setattr(main, 'ARCHIVE_DIR', tmp_path)
+    main.app.config['TESTING'] = True
+    main.app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    with main.app.app_context():
+        main.models_db.drop_all()
+        main.models_db.create_all()
+
+
+def create_image():
+    img = Image.new('RGB', (10, 10), color='red')
+    buf = BytesIO()
+    img.save(buf, format='PNG')
+    buf.seek(0)
+    return buf
+
+
+def test_preview_stored_on_upload(tmp_path, monkeypatch):
+    setup_env(tmp_path, monkeypatch)
+    with main.app.app_context():
+        user = main.User(username='u', password_hash=generate_password_hash('a'))
+        main.models_db.session.add(user)
+        main.models_db.session.commit()
+        uid = user.id
+    client = main.app.test_client()
+    client.post('/login', data={'username': 'u', 'password': 'a'})
+    buf = create_image()
+    resp = client.post('/upload', data={'image': (buf, 'a.png')}, content_type='multipart/form-data')
+    assert resp.status_code == 302
+    with main.app.app_context():
+        ds = main.Dataset.query.filter_by(owner_id=uid).first()
+        preview = tmp_path / f'user_{uid}' / ds.filename[:-4]
+        assert preview.exists()
+        assert len(list(preview.iterdir())) == 14
+
+
+def test_team_preview_accessible(tmp_path, monkeypatch):
+    setup_env(tmp_path, monkeypatch)
+    with main.app.app_context():
+        owner = main.User(username='o', password_hash=generate_password_hash('x'))
+        member = main.User(username='m', password_hash=generate_password_hash('y'))
+        main.models_db.session.add_all([owner, member])
+        main.models_db.session.commit()
+        team = main.Team(name='t', owner_id=owner.id)
+        main.models_db.session.add(team)
+        main.models_db.session.commit()
+        main.models_db.session.add_all([
+            main.TeamMember(team_id=team.id, user_id=owner.id),
+            main.TeamMember(team_id=team.id, user_id=member.id),
+        ])
+        main.models_db.session.commit()
+        team_id = team.id
+    client = main.app.test_client()
+    client.post('/login', data={'username': 'o', 'password': 'x'})
+    buf = create_image()
+    client.post('/upload', data={'image': (buf, 'a.png'), 'team_id': team_id}, content_type='multipart/form-data')
+    with main.app.app_context():
+        ds = main.Dataset.query.filter_by(team_id=team_id).first()
+        ds_id = ds.id
+    client.post('/login', data={'username': 'm', 'password': 'y'})
+    resp = client.get(f'/preview/{ds_id}')
+    assert resp.status_code == 200
+
+
+def test_preview_removed_on_delete(tmp_path, monkeypatch):
+    setup_env(tmp_path, monkeypatch)
+    with main.app.app_context():
+        user = main.User(username='u', password_hash=generate_password_hash('a'))
+        main.models_db.session.add(user)
+        main.models_db.session.commit()
+        uid = user.id
+    client = main.app.test_client()
+    client.post('/login', data={'username': 'u', 'password': 'a'})
+    buf = create_image()
+    client.post('/upload', data={'image': (buf, 'a.png')}, content_type='multipart/form-data')
+    with main.app.app_context():
+        ds = main.Dataset.query.filter_by(owner_id=uid).first()
+        preview = tmp_path / f'user_{uid}' / ds.filename[:-4]
+        assert preview.exists()
+        did = ds.id
+    resp = client.post(f'/delete/{did}')
+    assert resp.status_code == 302
+    assert not preview.exists()


### PR DESCRIPTION
## Summary
- save generated images for quick preview on upload
- remove preview directory on dataset deletion
- add gallery route with image list
- link to preview in team archive
- document previews in README
- cover preview behavior in tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687036c6abd483338a001db0b2c794ff