### PR TITLE
Add docker detection for maintainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ the personal archive.
 ## Setup using `maintainer.sh`
 
 The application is meant to be installed through the maintainer script. Run all
-commands with suitable privileges if installing system wide.
+commands with suitable privileges if installing system wide. When running
+inside the provided Docker container the script automatically detects the
+environment so `create-admin` and `start` work without calling `install` first.
 
 ```bash
 # clone into /opt/OneShot and install dependencies


### PR DESCRIPTION
## Summary
- detect docker and adjust maintainer paths
- allow `create-admin` and `start` without install in a container
- document the new behavior

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68756749d4fc833396da90b9e9d91983